### PR TITLE
Corrected how uart checks for more input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,26 @@ that includes the following:
 * A `bin` folder containing the release binaries.
 * A YAML file with various metadata about the release and which files are inluded.
 
+#### Deployment
+
+Travis-CI manages deploying a new release of these tools to Github Releases.
+
+To trigger a release, you simply have to push a tag with the version number of the new release:
+
+Locally, create a new tag with a version number for the release (we will use `1.0.0` as an example):
+
+```
+git tag 1.0.0
+```
+
+Then push the tag to Github:
+
+```
+git push --tags
+```
+
+Travis-CI will then handle everything and the new release binaries can be found under the Releases tab on Github.
+
 ### License
 
    Copyright 2012 Technical University of Denmark, DTU Compute.

--- a/include/uart.h
+++ b/include/uart.h
@@ -87,12 +87,22 @@ namespace patmos
       // available when there is something in the stream (DAV=0 or 1).
       // when the input stream reaches the end-of-file (EOF), signal a parity
       // error, i.e., PAE = 1.
-      // TODO EOF does not work in the hardware. Instead, use escape characters
-      //      or something to signal EOF over UART.
       *value = (1 << TRE);
-      if (In_stream.rdbuf()->in_avail())
+
+      // Get current position in input stream.
+      auto current_pos = In_stream.tellg();
+
+      // Get end position of input stream.
+      In_stream.seekg(0, In_stream.end);
+      auto end_pos = In_stream.tellg();
+
+      // Reset stream to current position since the last call to `seekg` changed position.
+      In_stream.seekg (current_pos, In_stream.beg);
+
+      // We cannot use 'In_stream.peek()' because it will block waiting for input.
+      if (current_pos < end_pos)
         *value |= (1 << DAV);
-      else if (In_stream.eof() || !IsTTY)
+      else
         *value |= (1 << PAE);
 
       return true;

--- a/include/uart.h
+++ b/include/uart.h
@@ -163,11 +163,7 @@ namespace patmos
         Data_address(base_address+0x04),
         In_stream(in_stream), IsTTY(istty),
         Out_stream(out_stream)
-    {
-      // Ensure that we can check the rd buffer of the streams
-      assert(In_stream.rdbuf() && Out_stream.rdbuf() &&
-             "UART expects streams associated with a buffer.");
-    }
+    {}
 
     /// A simulated access to a read port.
     /// @param address The memory address to read from.

--- a/src/pasim.cc
+++ b/src/pasim.cc
@@ -333,12 +333,6 @@ void disable_line_buffering()
 
 int main(int argc, char **argv)
 {
-  // the UART simulation may invoke cin.rdbuf()->in_avail(), which does not work
-  // properly when cin is synced with stdio. we thus disable it here, since we
-  // are not using stdio anyway.
-  disable_line_buffering();
-  std::cin.sync_with_stdio(false);
-
   // define command-line options
   boost::program_options::options_description generic_options(
     "Generic options:\n for memory/cache sizes the following units are allowed:"

--- a/tests/test23.s
+++ b/tests/test23.s
@@ -1,5 +1,5 @@
 #
-# Expected Result: r2 = 0x21
+# Expected Result: '!' is output, and r2 = 0x21
 #
 
                 .word   68;


### PR DESCRIPTION
Fixed #2 by correcting how UART checks whether there is more input.

Previously `In_stream.rdbuf()->in_avail()` was used to see if there was more input. This is not always correct as the buffer can be empty even though there is more input to be had.
The fix instead checks for whether the position we have reached in the input is the last. If it is, it means there is no more input to be had. There is no other way to do this, as all other methods might block on no input.

Also used this opportunity to remove other uses of `ifstream::rdbuf()` to minimize future bugs.