### PR TITLE
Fixes pasim's stdin not working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ script:
 - cd build
 - cmake ..
 - make
-- make test
+- ctest
+- ctest --rerun-failed -V
 - cd ..
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,15 @@ jobs:
       # We need GNU Tar instead of default BSD one for deployment
       - brew install gnu-tar
       - PATH="$(brew --prefix)/opt/gnu-tar/libexec/gnubin:$PATH"
+  allow_failures:
+    - os: osx
 
 script:
 - mkdir build
 - cd build
 - cmake ..
 - make
-- ctest
-- ctest --rerun-failed -V
+- ctest --output-on-failure
 - cd ..
 
 before_deploy:
@@ -39,4 +40,5 @@ deploy:
   on:
     tags: true
     repo: t-crest/patmos-simulator
+
 

--- a/include/uart.h
+++ b/include/uart.h
@@ -88,19 +88,7 @@ namespace patmos
       // when the input stream reaches the end-of-file (EOF), signal a parity
       // error, i.e., PAE = 1.
       *value = (1 << TRE);
-
-      // Get current position in input stream.
-      auto current_pos = In_stream.tellg();
-
-      // Get end position of input stream.
-      In_stream.seekg(0, In_stream.end);
-      auto end_pos = In_stream.tellg();
-
-      // Reset stream to current position since the last call to `seekg` changed position.
-      In_stream.seekg (current_pos, In_stream.beg);
-
-      // We cannot use 'In_stream.peek()' because it will block waiting for input.
-      if (current_pos < end_pos)
+      if (In_stream.rdbuf()->in_avail())
         *value |= (1 << DAV);
       else
         *value |= (1 << PAE);

--- a/src/pasim.cc
+++ b/src/pasim.cc
@@ -333,6 +333,12 @@ void disable_line_buffering()
 
 int main(int argc, char **argv)
 {
+  // the UART simulation may invoke cin.rdbuf()->in_avail(), which does not work
+  // properly when cin is synced with stdio. we thus disable it here, since we
+  // are not using stdio anyway.
+  disable_line_buffering();
+  std::cin.sync_with_stdio(false);
+  
   // define command-line options
   boost::program_options::options_description generic_options(
     "Generic options:\n for memory/cache sizes the following units are allowed:"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -163,13 +163,29 @@ macro (test_dsim num expr)
 endmacro (test_dsim)
 
 macro (test_io_sim num expr)
-  ADD_TEST(sim-test-${num} ${CMAKE_BINARY_DIR}/src/pasim -V --maxc 40000 --in ${PROJECT_SOURCE_DIR}/tests/test${num}.in ${CMAKE_CURRENT_BINARY_DIR}/test${num}.bin)
-  SET_TESTS_PROPERTIES(sim-test-${num} PROPERTIES PASS_REGULAR_EXPRESSION ${expr} DEPENDS asm-test-${num})
+  # Test input to program through '--in' command line argument
+  ADD_TEST(sim-test-file-input-${num} ${CMAKE_BINARY_DIR}/src/pasim -V --maxc 40000 --in ${PROJECT_SOURCE_DIR}/tests/test${num}.in ${CMAKE_CURRENT_BINARY_DIR}/test${num}.bin)
+  SET_TESTS_PROPERTIES(sim-test-file-input-${num} PROPERTIES PASS_REGULAR_EXPRESSION ${expr} DEPENDS asm-test-${num})
+  # Test input to program through stdin pipe to pasim  
+  ADD_TEST(sim-test-stdin-input-${num} ${CMAKE_COMMAND}
+    -DPASIM=${CMAKE_BINARY_DIR}/src/pasim
+	-DTEST_BIN=${CMAKE_CURRENT_BINARY_DIR}/test${num}.bin
+	-DINPUT_FILE=${PROJECT_SOURCE_DIR}/tests/test${num}.in
+	-P ${CMAKE_CURRENT_SOURCE_DIR}/sim-test-stdin-input-cmd.cmake)
+  SET_TESTS_PROPERTIES(sim-test-stdin-input-${num} PROPERTIES PASS_REGULAR_EXPRESSION ${expr} DEPENDS asm-test-${num})
 endmacro (test_io_sim)
 
 macro (test_elf_io_sim num expr)
-  ADD_TEST(sim-test-${num} ${CMAKE_BINARY_DIR}/src/pasim -V --maxc 40000 --in ${PROJECT_SOURCE_DIR}/tests/test${num}.in ${PROJECT_SOURCE_DIR}/tests/test${num}.elf)
-  SET_TESTS_PROPERTIES(sim-test-${num} PROPERTIES PASS_REGULAR_EXPRESSION ${expr})
+  # Test input to program through '--in' command line argument
+  ADD_TEST(sim-test-file-input-${num} ${CMAKE_BINARY_DIR}/src/pasim -V --maxc 40000 --in ${PROJECT_SOURCE_DIR}/tests/test${num}.in ${PROJECT_SOURCE_DIR}/tests/test${num}.elf)
+  SET_TESTS_PROPERTIES(sim-test-file-input-${num} PROPERTIES PASS_REGULAR_EXPRESSION ${expr})
+  # Test input to program through stdin pipe to pasim
+  ADD_TEST(sim-test-stdin-input-${num} ${CMAKE_COMMAND}
+    -DPASIM=${CMAKE_BINARY_DIR}/src/pasim
+	-DTEST_BIN=${PROJECT_SOURCE_DIR}/tests/test${num}.elf
+	-DINPUT_FILE=${PROJECT_SOURCE_DIR}/tests/test${num}.in
+	-P ${CMAKE_CURRENT_SOURCE_DIR}/sim-test-stdin-input-cmd.cmake)
+  SET_TESTS_PROPERTIES(sim-test-stdin-input-${num} PROPERTIES PASS_REGULAR_EXPRESSION ${expr})
 endmacro (test_elf_io_sim)
 
 macro (test_sim_lp num expr)

--- a/tests/sim-test-stdin-input-cmd.cmake
+++ b/tests/sim-test-stdin-input-cmd.cmake
@@ -1,0 +1,11 @@
+message("Test command: cat ${INPUT_FILE} | ${PASIM} -V --maxc 40000 ${TEST_BIN}")
+execute_process(
+	COMMAND cat ${INPUT_FILE}
+	COMMAND ${PASIM} -V --maxc 40000 ${TEST_BIN}  
+	OUTPUT_VARIABLE OUT ERROR_VARIABLE OUT 
+	RESULT_VARIABLE CMD_RESULT
+)
+message("${OUT}")
+if(CMD_RESULT)
+	message(FATAL_ERROR "Error running test")
+endif()


### PR DESCRIPTION
Fixes #4 by reverting the fix to #2. Travis now allows to OSX build to fail.

The fix didn't work because the `seekg()` methods on `istream` only work if the stream if backed by a file. Since stdin is piped in this case, there is no end to the stream, which means we cannot check for whether we have reached it.

I have been unable to find a cross-platform way to check for more input from a stream without blocking. Therefore, I have given up for now on supporting OSX, as that seems to be the least invasive choice (for years, no one noticed that pasim didn't actually work on OSX).
