### PR TITLE
Now statically links Boost's program_options.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,62 @@
 language: cpp
 compiler: gcc
+os: linux
+dist: bionic
+
+cache:
+  directories: 
+  - build/
+  
+import:
+- source: ci/deploy_config.yml
+  if: DEPLOYMENT = deploy
 
 jobs:
+  allow_failures:
+  - os: osx
   include:
-    - os: linux
-      dist: bionic
-      before_script:
+    - stage: "Clear cache"
+    # Bionic
+      script: rm -rf build
+    # MacOs
+    - script: rm -rf build
+      os: osx
+      
+    - stage: "Build"
+    # Bionic
+      script: ci/build.sh
+      before_script: 
       - sudo apt-get update -qq
       - sudo apt-get install libboost-dev libboost-program-options-dev
-    - os: osx
+    # MacOs
+    - script: ci/build.sh
+      os: osx
       before_script:
       - brew install libelf
       # We need GNU Tar instead of default BSD one for deployment
       - brew install gnu-tar
       - PATH="$(brew --prefix)/opt/gnu-tar/libexec/gnubin:$PATH"
-  allow_failures:
+      
+    - stage: "Test"
+    # Bionic
+      script: ci/test.sh
+    # MacOs
+    - script: ci/test.sh
+      os: osx
+      after_success: touch build/osx_test_success
+    
+    - stage: "Deploy"
+    # Bionic
+      if: tag IS present
+      script: skip
+      env: DEPLOYMENT=deploy
+    # MacOs  
     - os: osx
-
-script:
-- mkdir build
-- cd build
-- cmake ..
-- make
-- ctest --output-on-failure
-- cd ..
-
-before_deploy:
-- cd build
-- make box
-- cd ..
-
-deploy:
-- provider: releases
-  api_key:
-    secure: Tx8Cly4BWULJRyi5hgqvzz/IBhvqCKrGTulYzwdMLN34jBY6u4DvvAoFh1Zq4GXl9bm7Ire8Fjta7+PNorUYFgO6vnqL8GZ+sBR4FMNp/6XIt2xJqW/L4G6pdxV3BxdspAbVWLeMGH7FF8jNPmeWmTvRJbItgagG6cYUtEiiV9+e9E6aSiGQM2zkHSKmcRWHexf30iaR2pVSXzIWb2/hPlqQBj/bTXqEeTXkdiHH2/BtFjA7GmR45WbQUH48Nl94LDAFHW+TSJty0dw3wRxiF4O4bQIqlUmBSLrxcI344uQMu2M3u09N+PcJ1wgtacxRFbtK5FfrpatyjJPdjjb35klgCasGX33ktDLCcQW/g2qI8e2DdNQ9GfUCDmoIRxqQaoqRVMOkf0/KF2A+djlnTryYjwAVCmoRwmCX82wAG9WOsrhfN6HtuXIlCqj535Yqyey7G8OSB64qL+551RwQKUwrAM9Px3eH42epxKUgOIbQ1Arew0n2C3YnnJYE+xV15v3dyuitfQJSNOSaTk0HZ2kKocPiW0aPBJQLK/29bss3GVmL3MhsRlxnczs0wW3onz0p50FJ6ebrM90GcGOLH5tuyOjcXZM8dDcy6oPKgBhYJ9zKLQ5l++rlpkcIrjTyQnGGVfllCqmEcHXYYqBDYU9rNmbPANiJSRt41lNXi98=
-  file_glob: true
-  file: "build/patmos-simulator*.tar.gz"
-  skip_cleanup: true
-  on:
-    tags: true
-    repo: t-crest/patmos-simulator
-
-
+      if: tag IS present
+      script: skip
+      env: DEPLOYMENT=deploy
+      # We need GNU Tar instead of default BSD one for deployment
+      before_script:
+      - test -f build/osx_test_success
+      - brew install gnu-tar
+      - PATH="$(brew --prefix)/opt/gnu-tar/libexec/gnubin:$PATH"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
 
 # Find boost library
 include(FindBoost)
+set(Boost_USE_STATIC_LIBS ON)
 find_package( Boost 1.46.0 COMPONENTS program_options REQUIRED)
 
 # Find libelf

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,14 @@
+Continuous Integration scripts
+====================
+
+These scripts are meant to be run by Travis-CI for testing and deploying the project binaries.
+However, they can also be used to build/test the project locally.
+These scripts are meant to be run from the project root folder (`cd ..` from this folder.)
+
+The scripts should be run in the following order:
+
+- `build`
+- `test`
+
+Running them in a different order or skipping any of them may result in errors.
+

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -x
+# Build the simulator
+set -e
+
+mkdir -p build
+cd build
+cmake ..
+make
+cd ..

--- a/ci/deploy_config.yml
+++ b/ci/deploy_config.yml
@@ -1,0 +1,15 @@
+
+before_deploy:
+- cd build
+- make box
+- cd ..
+deploy:
+- provider: releases
+  api_key:
+    secure: Tx8Cly4BWULJRyi5hgqvzz/IBhvqCKrGTulYzwdMLN34jBY6u4DvvAoFh1Zq4GXl9bm7Ire8Fjta7+PNorUYFgO6vnqL8GZ+sBR4FMNp/6XIt2xJqW/L4G6pdxV3BxdspAbVWLeMGH7FF8jNPmeWmTvRJbItgagG6cYUtEiiV9+e9E6aSiGQM2zkHSKmcRWHexf30iaR2pVSXzIWb2/hPlqQBj/bTXqEeTXkdiHH2/BtFjA7GmR45WbQUH48Nl94LDAFHW+TSJty0dw3wRxiF4O4bQIqlUmBSLrxcI344uQMu2M3u09N+PcJ1wgtacxRFbtK5FfrpatyjJPdjjb35klgCasGX33ktDLCcQW/g2qI8e2DdNQ9GfUCDmoIRxqQaoqRVMOkf0/KF2A+djlnTryYjwAVCmoRwmCX82wAG9WOsrhfN6HtuXIlCqj535Yqyey7G8OSB64qL+551RwQKUwrAM9Px3eH42epxKUgOIbQ1Arew0n2C3YnnJYE+xV15v3dyuitfQJSNOSaTk0HZ2kKocPiW0aPBJQLK/29bss3GVmL3MhsRlxnczs0wW3onz0p50FJ6ebrM90GcGOLH5tuyOjcXZM8dDcy6oPKgBhYJ9zKLQ5l++rlpkcIrjTyQnGGVfllCqmEcHXYYqBDYU9rNmbPANiJSRt41lNXi98=
+  file_glob: true
+  file: "build/patmos-simulator*.tar.gz"
+  skip_cleanup: true
+  on:
+    tags: true
+    repo: t-crest/patmos-simulator

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -x
+# Run automatic tests
+set -e
+
+cd build
+ctest --verbose --output-on-failure
+cd ..


### PR DESCRIPTION
Also split CI setup into stages to ensure the right testing conditions (namely the absense of program_options).
Fixes #6.