### PR TITLE
Added test and C++14 requiremet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,11 @@
 
 project(patmos)
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(USE_RAMULATOR "USE_RAMULATOR" OFF)
 

--- a/src/data-cache.cc
+++ b/src/data-cache.cc
@@ -346,6 +346,8 @@ void set_assoc_data_cache_t<LRU_REPLACEMENT>::flush_cache()
   }
 }
 
-// Explicit instantiation of template class for linking.
-template class set_assoc_data_cache_t<false>;
-template class set_assoc_data_cache_t<true>;
+namespace patmos {
+  // Explicit instantiation of template class for linking.
+  template class set_assoc_data_cache_t<false>;
+  template class set_assoc_data_cache_t<true>;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,6 +148,8 @@ Errors : 0")
 test_asm(51 "Emitted: 72 bytes
 Errors : 0")
 
+test_asm(52 "Emitted: 40 bytes
+Errors : 0")
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # SIMULATOR TESTS
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -316,3 +318,5 @@ test_sim_scba(50 "Align .*spill.*:          2           2
    Align .*free.*:          4           4")
 
 test_sim(51 "r1 : 00400000   r2 : 003ffffb   r3 : 00000005")
+
+test_sim(52 "Cycle ([0-9]|[a-f])*: Illegal instruction at ([0-9]|[a-f])*: Use of load result without delay slot!")

--- a/tests/test52.s
+++ b/tests/test52.s
@@ -1,0 +1,15 @@
+#
+# Tests whether pasim issues an error if the destination register
+# of a load is used in the delay slot
+# Expected Result: Error because of the lack of delay slot
+#
+
+                .word   40;
+                add     r1  = r0, 0xF0080000;
+                addi    r2  = r0, 2;
+                lwl     r3  = [r1 + 0];
+                addi    r8  = r3, 1; # Illegal use of r3
+                halt;
+                nop;
+                nop;
+                nop;


### PR DESCRIPTION
Fixes #13 
Fixes #14

The only notable change is that we now require a minimum cmake version of 3.1 (up from 2.8).
3.1 was released in 2016 so it (or a later version) should be available on practically everyone's machine.