### PR TITLE
Error messages can now print the relevant instruction.

### DIFF
--- a/src/excunit.cc
+++ b/src/excunit.cc
@@ -260,24 +260,6 @@ namespace patmos
     }
   }
 
-  void excunit_t::illegal(uword_t iw)
-  {
-    if (may_fire(ET_ILLEGAL_OPERATION)) {
-      fire_exception(ET_ILLEGAL_OPERATION);
-    } else {
-      simulation_exception_t::illegal(iw);
-    }
-  }
-
-  void excunit_t::illegal(std::string msg)
-  {
-    if (may_fire(ET_ILLEGAL_OPERATION)) {
-      fire_exception(ET_ILLEGAL_OPERATION);
-    } else {
-      simulation_exception_t::illegal(msg);
-    }
-  }
-
   void excunit_t::unmapped(uword_t address)
   {
     if (may_fire(ET_ILLEGAL_ADDRESS)) {

--- a/src/simulation-core.cc
+++ b/src/simulation-core.cc
@@ -142,7 +142,14 @@ namespace patmos
 
       // simulate the respective pipeline stage of the instruction
       if (f) {
-        (Pipeline[pst][i].*f)(*this);
+        try {
+          (Pipeline[pst][i].*f)(*this);
+        }
+        catch (patmos::simulation_exception_t e)
+        {
+          e.set_offending_instruction(Pipeline[pst][i]);
+          throw e;
+        }
       }
     }
 
@@ -388,7 +395,9 @@ namespace patmos
                       // The previous load instruction is being executed
                       PRR.get(Pipeline[SMW][0].Pred).get())
                 {
-                  simulation_exception_t::illegal("Use of load result without delay slot!");
+                  simulation_exception_t::illegal("Use of load result without delay slot!",
+                    Pipeline[SEX][j]
+                  );
                 }
               }
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -241,13 +241,13 @@ test_sim(13 "BASE: 00000004   PC : 0000002c.*
 
 test_sim(14 "r0 : 00000000   r1 : 0283f181   r2 : 0283f181   r3 : 00000283   r4 : ffffff83   r5 : 00000283   r6 : 00000083")
 
-test_sim(15 "Unmapped memory access at 00000014: fffffffc")
+test_sim(15 "\\\\\\[Error\\\\\\] Unmapped memory access: fffffffc(.)*(0)*8:( )*lwm r1 = \\\\\\[r1 \\\\\\+ 0\\\\\\](.)*PC : 00000014")
 
-test_sim(16 "Stack size exceeded at 00000020")
+test_sim(16 "\\\\\\[Error\\\\\\] Stack size exceeded(.)*(0)*14:( )*lws r1 = \\\\\\[r0 \\\\\\+ 5\\\\\\](.)*PC : 00000020")
 
-test_sim(17 "Stack size exceeded at 00000024")
+test_sim(17 "\\\\\\[Error\\\\\\] Stack size exceeded(.)*(0)*18:( )*lws r1 = \\\\\\[r1 \\\\\\+ 0\\\\\\](.)*PC : 00000024")
 
-test_sim(18 "Stack size exceeded at 0000000c")
+test_sim(18 "\\\\\\[Error\\\\\\] Stack size exceeded(.)*(0)*4:( )*sres 4(.)*PC : 0000000c")
 
 test_sim(19 "r1 : 00000007")
 
@@ -319,4 +319,4 @@ test_sim_scba(50 "Align .*spill.*:          2           2
 
 test_sim(51 "r1 : 00400000   r2 : 003ffffb   r3 : 00000005")
 
-test_sim(52 "Cycle ([0-9]|[a-f])*: Illegal instruction at ([0-9]|[a-f])*: Use of load result without delay slot!")
+test_sim(52 "\\\\\\[Error\\\\\\] Illegal instruction: Use of load result without delay slot!(.)*(0)*14:( )*addil r8 = r3, 1")


### PR DESCRIPTION
In addition to the previous information provided by an
error (cycle count, PC, stack trace), the relevant instruction
in the program that caused the error is also provided (with its address).
An instruction is only provided where relevant.

To give an example of the difference, say we have the following program:
```asm
00000000                .word   28;
00000004                subi	r1  = r31, 4;
00000008                lwm     r1  = [r1 + 0];
0000000c                halt;
00000010                nop;
00000014                nop;
00000018                nop;
```
This will fail because the `lwm` is loading from an invalid memory address.
before this change, the following would be printed:
```
Cycle 4: Unmapped memory access at 00000014: fffffffc
Stacktrace:
#0 0x4 (): $rsp 0x7fffffff stack cache size 0x0
   at 0x14 (base: 0x4 , offset: 0x10 )
```
This is not very informative, as we are being presented with the program counter address `00000014` which doesn't match the relevant instruction in our program. We are also not told what this address is for, so the user must know on their own that it cannot be used to find the offending instruction.

The new error message would be:
```
[Error] Unmapped memory access: fffffffc

00000008:              lwm r1 = [r1 + 0]

Cycle : 4, PC : 00000014
Stacktrace:
#0 0x4 (): $rsp 0x7fffffff stack cache size 0x0
   at 0x14 (base: 0x4 , offset: 0x10 )
```
Here we are pointed to the offending instruction both through address (`00000008`) and by showing the instruction directly.
We also still retain the same information as before, however, now its more clear what all the numbers are (The `00000014` is now preceded by `PC :` to clarify that this is the current program counter).